### PR TITLE
Fix examples in cyclic linking cases with value exports from JS

### DIFF
--- a/proposals/esm-integration/EXAMPLES.md
+++ b/proposals/esm-integration/EXAMPLES.md
@@ -199,7 +199,7 @@ export {memoryExport} from "./b.wasm";
 #### JS exports
 | export type | value (not a `WebAssembly.Global`)* | global | memory | table | function |
 |-|-------------------------------|--------|--------|-------|----------|
-| | `0` if a const import and not in TDZ, otherwise `Error` | `Error`  | `Error`  | `Error` | snapshot if it is a function declaration, otherwise `Error` |
+| | `Error` | `Error`  | `Error`  | `Error` | snapshot if it is a function declaration, otherwise `Error` |
 
 #### wasm exports
 | export type | global       | memory       | table        | function     |
@@ -241,7 +241,7 @@ export function functionExport() {
 #### JS exports
 | export type | value (not a WebAssembly.Global)* | global | memory | table | function |
 |-|-------------------------------|--------|--------|-------|----------|
-| | `Error`                         | snapshot  | snapshot  | snapshot | snapshot |
+| | If the value is a Number or BigInt, it will be converted appropriately. Otherwise `Error`. | snapshot  | snapshot  | snapshot | snapshot |
 
 1. wasm module is parsed
 1. JS module is parsed


### PR DESCRIPTION
As explained in #55 and #58, I think the cyclic linking examples are not quite right for the cases where a plain value is being exported from JS.

In the JS is higher case, the JS binding is `undefined` when not TDZ. Global imports in Wasm [only accept Number or BigInt](https://webassembly.github.io/esm-integration/js-api/index.html#read-the-imports) though, so the `undefined` can't be converted.

In the Wasm is higher case, the current example shows error. But since the value binding should be available by the time Wasm reads the import, it should just be a snapshot I think and succeed if it's a Number or BigInt.