### PR TITLE
Fix Wasm<->Wasm import signature

### DIFF
--- a/proposals/esm-integration/EXAMPLES.md
+++ b/proposals/esm-integration/EXAMPLES.md
@@ -156,7 +156,7 @@ Wasm exports can be imported as accurate, immutable bindings to other wasm modul
 ;; main.wat --> main.wasm
 (module
   (import "./counter.wasm" "count" (global i32))
-  (import "./counter.wasm" "increment" (func $increment (result i32)))
+  (import "./counter.wasm" "increment" (func $increment))
 )
 
 ;; counter.wat --> counter.wasm


### PR DESCRIPTION
Fixes #66.

The import function's type signature didn't match the implementation's type signature.