### PR TITLE
Update on top of the new ECMA-262 module loading logic

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -99,7 +99,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     type: abstract-op
         text: CreateDataPropertyOrThrow; url: sec-createdatapropertyorthrow
         text: CreateMethodProperty; url: sec-createmethodproperty
-        text: HostResolveImportedModule; url: sec-hostresolveimportedmodule
+        text: GetImportedModule; url: url-GetImportedModule
         text: NewModuleEnvironment; url: sec-newmoduleenvironment
         text: OrdinaryObjectCreate; url: sec-ordinaryobjectcreate
 urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
@@ -1264,16 +1264,18 @@ To <dfn export>parse a WebAssembly module</dfn> given a an {{ArrayBuffer}} |byte
       \[[Namespace]]: undefined,
       \[[HostDefined]]: |hostDefined|,
       <!-- Cyclic Module Records -->
-      \[[Status]]: "unlinked",
+      \[[Status]]: "new",
       \[[EvaluationError]]: undefined,
       \[[DFSIndex]]: undefined,
       \[[DFSAncestorIndex]]: undefined,
       \[[RequestedModules]]: |requestedModules|,
-      \[[Async]]: true,
-      \[[AsyncEvaluating]]: false,
-      \[[TopLevelCapability]]: undefined
-      \[[AsyncParentModules]]: undefined,
-      \[[PendingAsyncDependencies]]: undefined,
+      \[[LoadedModules]]: &laquo; &raquo;,
+      \[[CycleRoot]]: ~empty~,
+      \[[HasTLA]]: true,
+      \[[AsyncEvaluation]]: true,
+      \[[TopLevelCapability]]: ~empty~
+      \[[AsyncParentModules]]: &laquo; &raquo;,
+      \[[PendingAsyncDependencies]]: ~empty~,
       <!-- WebAssembly Module Records -->
       \[[WebAssemblyModule]]: |module|
     }.
@@ -1327,14 +1329,12 @@ WebAssembly Module Records have the following methods:
 <h3 id="module-execution">ExecuteModule ( [ |promiseCapability| ] ) Concrete Method</h3>
 1. Assert: |promiseCapability| was provided.
 1. Let |record| be this WebAssembly Module Record.
-1. Assert: |record|.\[[Async]] is true.
-1. Assert: |record|.\[[ModuleAsync]] is true.
+1. Assert: |record|.\[[HasTLA]] is true.
 1. Let |module| be |record|.\[[WebAssemblyModule]].
 1. Let |imports| be a new, empty [=map=].
 1. For each (|importedModuleName|, |name|, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
     1. If |imports|[|importedModuleName|] does not exist, set |imports|[|importedModuleName|] to a new, empty [=map=].
-    1. Let |importedModule| be ! [$HostResolveImportedModule$](|record|, |importedModuleName|).
-    1. NOTE: The above call cannot fail because imported module requests are a subset of |record|.\[[RequestedModules]], and these have been resolved earlier in this algorithm.
+    1. Let |importedModule| be [$GetImportedModule$](|record|, |importedModuleName|).
     1. Let |value| be ? |importedModule|.\[[Environment]].GetBindingValue(|name|, true).
     1. Set |imports|[|importedModuleName|][|name|] to |value|.
 1. Let |importsObject| be ! [$OrdinaryObjectCreate$](null).
@@ -1347,9 +1347,9 @@ WebAssembly Module Records have the following methods:
 1. [=Upon fulfillment=] of |instancePromise| with value |instance|:
     1. For each |name| in the [=export name list=] of |record|,
         1. Perform ! |record|.\[[Environment]].InitializeBinding(|name|, ! Get(|instance|.\[[Exports]], |name|)).
-    1. Perform ! [=Call=](|promiseCapability|.\[[Resolve]], undefined, undefined).
+    1. Perform ! [=Call=](|promiseCapability|.\[[Resolve]], undefined, &laquo; undefined &raquo;).
 1. [=Upon rejection=] of |instancePromise| with reason |r|:
-    1. Perform ! [=Call=](|promiseCapability|.\[[Reject]], undefined, |r|).
+    1. Perform ! [=Call=](|promiseCapability|.\[[Reject]], undefined, &laquo; |r| &raquo;).
 
     Note: exported bindings are left uninitialized, i.e., in TDZ.
 


### PR DESCRIPTION
https://github.com/tc39/ecma262/pull/2905 removes `HostResolveImportedModule`, replacing it with `GetImportedModule` (which never fails, and doesn't call into the host spec).

Additionally, some of the fields in the WebAssembly Module Record had outdated names.