### PR TITLE
Integrate with Module Source Imports proposal

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1355,4 +1355,13 @@ WebAssembly Module Records have the following methods:
 
 </div>
 
+<div algorithm=GetModuleSource>
+
+<h3 id="get-module-source">GetModuleSource ( ) Concrete Method</h3>
+1. Let |record| be this WebAssembly Module Record.
+1. Let |module| be |record|.\[[WebAssemblyModule]].
+1. Return |module|.
+
+</div>
+
 Note: See corresponding modifications to HTML in <a href="https://github.com/whatwg/html/pull/4372">PR #4372</a>.

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -99,7 +99,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
     type: abstract-op
         text: CreateDataPropertyOrThrow; url: sec-createdatapropertyorthrow
         text: CreateMethodProperty; url: sec-createmethodproperty
-        text: HostResolveImportedModule; url: sec-hostresolveimportedmodule
+        text: GetImportedModule; url: url-GetImportedModule
         text: NewModuleEnvironment; url: sec-newmoduleenvironment
         text: OrdinaryObjectCreate; url: sec-ordinaryobjectcreate
 urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
@@ -1264,16 +1264,18 @@ To <dfn export>parse a WebAssembly module</dfn> given a an {{ArrayBuffer}} |byte
       \[[Namespace]]: undefined,
       \[[HostDefined]]: |hostDefined|,
       <!-- Cyclic Module Records -->
-      \[[Status]]: "unlinked",
+      \[[Status]]: "new",
       \[[EvaluationError]]: undefined,
       \[[DFSIndex]]: undefined,
       \[[DFSAncestorIndex]]: undefined,
       \[[RequestedModules]]: |requestedModules|,
-      \[[Async]]: true,
-      \[[AsyncEvaluating]]: false,
-      \[[TopLevelCapability]]: undefined
-      \[[AsyncParentModules]]: undefined,
-      \[[PendingAsyncDependencies]]: undefined,
+      \[[LoadedModules]]: &laquo; &raquo;,
+      \[[CycleRoot]]: ~empty~,
+      \[[HasTLA]]: true,
+      \[[AsyncEvaluation]]: true,
+      \[[TopLevelCapability]]: ~empty~
+      \[[AsyncParentModules]]: &laquo; &raquo;,
+      \[[PendingAsyncDependencies]]: ~empty~,
       <!-- WebAssembly Module Records -->
       \[[WebAssemblyModule]]: |module|
     }.
@@ -1327,14 +1329,12 @@ WebAssembly Module Records have the following methods:
 <h3 id="module-execution">ExecuteModule ( [ |promiseCapability| ] ) Concrete Method</h3>
 1. Assert: |promiseCapability| was provided.
 1. Let |record| be this WebAssembly Module Record.
-1. Assert: |record|.\[[Async]] is true.
-1. Assert: |record|.\[[ModuleAsync]] is true.
+1. Assert: |record|.\[[HasTLA]] is true.
 1. Let |module| be |record|.\[[WebAssemblyModule]].
 1. Let |imports| be a new, empty [=map=].
 1. For each (|importedModuleName|, |name|, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
     1. If |imports|[|importedModuleName|] does not exist, set |imports|[|importedModuleName|] to a new, empty [=map=].
-    1. Let |importedModule| be ! [$HostResolveImportedModule$](|record|, |importedModuleName|).
-    1. NOTE: The above call cannot fail because imported module requests are a subset of |record|.\[[RequestedModules]], and these have been resolved earlier in this algorithm.
+    1. Let |importedModule| be [$GetImportedModule$](|record|, |importedModuleName|).
     1. Let |value| be ? |importedModule|.\[[Environment]].GetBindingValue(|name|, true).
     1. Set |imports|[|importedModuleName|][|name|] to |value|.
 1. Let |importsObject| be ! [$OrdinaryObjectCreate$](null).
@@ -1347,9 +1347,9 @@ WebAssembly Module Records have the following methods:
 1. [=Upon fulfillment=] of |instancePromise| with value |instance|:
     1. For each |name| in the [=export name list=] of |record|,
         1. Perform ! |record|.\[[Environment]].InitializeBinding(|name|, ! Get(|instance|.\[[Exports]], |name|)).
-    1. Perform ! [=Call=](|promiseCapability|.\[[Resolve]], undefined, undefined).
+    1. Perform ! [=Call=](|promiseCapability|.\[[Resolve]], undefined, &laquo; undefined &raquo;).
 1. [=Upon rejection=] of |instancePromise| with reason |r|:
-    1. Perform ! [=Call=](|promiseCapability|.\[[Reject]], undefined, |r|).
+    1. Perform ! [=Call=](|promiseCapability|.\[[Reject]], undefined, &laquo; |r| &raquo;).
 
     Note: exported bindings are left uninitialized, i.e., in TDZ.
 


### PR DESCRIPTION
This commit integrates the Wasm ESM integration with the TC39 Module
Source Imports proposal. The [Module Source Imports proposal](https://tc39.es/proposal-source-phase-imports/) allows
performing a JS import that early returns from the module loader at an
earlier stage than evaluation, specifically after "fetch/compile".

```js
import source mod from "./test.wasm";
mod instanceof WebAssembly.Module; // true
```

This enables Wasm-ESM integration for tooling that can not adopt "full"
ESM because of the need for manual instantiation.