### PR TITLE
Import CI workflows from the WebAssembly/spec repo

### DIFF
--- a/.github/workflows/ci-interpreter.yml
+++ b/.github/workflows/ci-interpreter.yml
@@ -1,0 +1,34 @@
+name: CI for interpreter & tests
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ interpreter/**, test/** ]
+
+  pull_request:
+    branches: [ main ]
+    paths: [ interpreter/**, test/** ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  interpreter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.12.x
+      - name: Setup OCaml tools
+        run: opam install --yes ocamlbuild.0.14.0 ocamlfind.1.9.5 js_of_ocaml.4.0.0 js_of_ocaml-ppx.4.0.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 19.x
+      - name: Build interpreter
+        run: cd interpreter && opam exec make
+      - name: Run tests
+        run: cd interpreter && opam exec make JS=node ci

--- a/.github/workflows/ci-spec.yml
+++ b/.github/workflows/ci-spec.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI for specs
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,88 +3,98 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths: [ document/** ]
+
   pull_request:
     branches: [ main ]
+    paths: [ document/** ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
-  ref-interpreter:
+  build-core-spec:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v2
+      - name: Checkout repo
+        uses: actions/checkout@v2
         with:
-          ocaml-compiler: 4.12.x
-      - run: opam install --yes ocamlbuild.0.14.0
-      - run: cd interpreter && opam exec make all
+          submodules: "recursive"
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Setup Bikeshed
+        run: pip install bikeshed && bikeshed update
+      - name: Setup TexLive
+        run: sudo apt-get update -y && sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+      - name: Setup Sphinx
+        run: pip install six && pip install sphinx==5.1.0
+      - name: Build main spec
+        run: cd document/core && make main
+      - name: Run Bikeshed
+        run: cd document/core && make bikeshed
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: core-rendered
+          path: document/core/_build/html
 
   build-js-api-spec:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Build JS API bikeshed
-        uses: netwerk-digitaal-erfgoed/bikeshed-action@v1
-        with:
-          source: "document/js-api/index.bs"
-          destination: "document/js-api/index.html"
-      - uses: actions/upload-artifact@v2
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Bikeshed
+        run: pip install bikeshed && bikeshed update
+      - name: Run Bikeshed
+        run: bikeshed spec "document/js-api/index.bs" "document/js-api/index.html"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
         with:
           name: js-api-rendered
-          path: document/js-api
+          path: document/js-api/index.html
 
   build-web-api-spec:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Build JS API bikeshed
-        uses: netwerk-digitaal-erfgoed/bikeshed-action@v1
-        with:
-          source: "document/web-api/index.bs"
-          destination: "document/web-api/index.html"
-      - uses: actions/upload-artifact@v2
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Bikeshed
+        run: pip install bikeshed && bikeshed update
+      - name: Run Bikeshed
+        run: bikeshed spec "document/web-api/index.bs" "document/web-api/index.html"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
         with:
           name: web-api-rendered
-          path: document/web-api
-
-  build-core-spec:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: "recursive"
-      - run: pip install bikeshed && bikeshed update
-      - run: pip install six
-      - run: sudo apt-get update -y && sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
-      - run: pip install sphinx==3.5.2
-      - run: cd document/core && make all
-      - uses: actions/upload-artifact@v2
-        with:
-          name: core-api-rendered
-          path: document/core/_build/html
+          path: document/web-api/index.html
 
   publish-spec:
     runs-on: ubuntu-latest
     needs: [build-core-spec, build-js-api-spec, build-web-api-spec]
     steps:
-      - uses: actions/checkout@v2
-      - run: mkdir _output && cp document/index.html _output/index.html
-      - uses: actions/download-artifact@v2
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Create output directory
+        run: mkdir _output && cp document/index.html _output/index.html
+      - name: Download core spec artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: core-rendered
+          path: _output/core
+      - name: Download JS API spec artifact
+        uses: actions/download-artifact@v2
         with:
           name: js-api-rendered
           path: _output/js-api
-      - uses: actions/download-artifact@v2
+      - name: Download Web API spec artifact
+        uses: actions/download-artifact@v2
         with:
           name: web-api-rendered
           path: _output/web-api
-      - uses: actions/download-artifact@v2
-        with:
-          name: core-api-rendered
-          path: _output/core
-      - name: Publish HTML to GitHub Pages
-        if: github.ref == 'refs/heads/master'
+      - name: Publish to GitHub Pages
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           publish_dir: ./_output


### PR DESCRIPTION
This PR copies the relevant files from https://github.com/WebAssembly/spec/tree/main/.github/workflows. CI in this repo is currently failing (https://github.com/WebAssembly/esm-integration/actions/runs/5190630699); this PR hopefully fixes it.

