### PR TITLE
add CSP policy note

### DIFF
--- a/proposals/esm-integration/README.md
+++ b/proposals/esm-integration/README.md
@@ -141,6 +141,14 @@ Some impacts of reading the imports up-front:
 
 See the FAQ for more explanation of the rationale for this design decision, and what features it enables which would be difficult or impossible otherwise.
 
+### Content Security Policy
+
+CSP policies are verified at the time of Wasm compilation through the `HostEnsureCanCompileWasmBytes` abstract
+operation.
+
+Wasm modules loaded through the ES Module system should follow the existing `script-src` policy on the page when
+compiled through the module system hooks. Further refinements to the Wasm CSP policy may then be added in future.
+
 ## FAQ
 
 ### How would this work, in some concrete examples?

--- a/proposals/esm-integration/README.md
+++ b/proposals/esm-integration/README.md
@@ -144,10 +144,11 @@ See the FAQ for more explanation of the rationale for this design decision, and 
 ### Content Security Policy
 
 CSP policies are verified at the time of Wasm compilation through the `HostEnsureCanCompileWasmBytes` abstract
-operation.
+operation defined by the [Web Content Security Policy proposal](https://github.com/WebAssembly/content-security-policy).
 
-Wasm modules loaded through the ES Module system should follow the existing `script-src` policy on the page when
-compiled through the module system hooks. Further refinements to the Wasm CSP policy may then be added in future.
+Wasm modules imported through the ES Module system should be verified for compilation by CSP against the `script-src`
+directive, both for static and dynamic imports. This allows Wasm and JS to be equally supported in the ESM
+integration under CSP policies. Further refinements to the Wasm CSP policy may be added in future.
 
 ## FAQ
 

--- a/proposals/esm-integration/README.md
+++ b/proposals/esm-integration/README.md
@@ -143,12 +143,12 @@ See the FAQ for more explanation of the rationale for this design decision, and 
 
 ### Content Security Policy
 
-CSP policies are verified at the time of Wasm compilation through the `HostEnsureCanCompileWasmBytes` abstract
-operation defined by the [Web Content Security Policy proposal](https://github.com/WebAssembly/content-security-policy).
-
 Wasm modules imported through the ES Module system should be verified for compilation by CSP against the `script-src`
 directive, both for static and dynamic imports. This allows Wasm and JS to be equally supported in the ESM
-integration under CSP policies. Further refinements to the Wasm CSP policy may be added in future.
+integration under CSP policies.
+
+While Wasm is currently fully sandboxed, having equal access to imports to JS provides it equal capabilities to
+execution primitives, so that it should not be considered a weaker capability from an ESM integration perspective.
 
 ## FAQ
 


### PR DESCRIPTION
Since the Wasm CSP proposal is Phase 3, it seems prudent to make a note now as to how the ESM Integration interacts with the CSP proposal. Depending on which progresses into the spec first, the correct rebasing of specification can then happen at that time, but at least this ensures there is no ambiguity in this area for now as implementations seek to progress.