### PR TITLE
Use AbstractModuleSource [[ModuleSource]] slot

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -20,7 +20,7 @@ Date: now
 {
   "SOURCEPHASEIMPORTS": {
     "href": "https://tc39.es/proposal-source-phase-imports/",
-    "title": "Top-Level Await"
+    "title": "Source Phase Imports"
   },
   "WEBASSEMBLY": {
     "href": "https://webassembly.github.io/spec/core/",
@@ -77,10 +77,9 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: Array; url: sec-array-exotic-objects
         text: BigInt; url: sec-ecmascript-language-types-bigint-type
         text: CreateArrayFromList; url: sec-createarrayfromlist
+        text: Cyclic Module Record; url: cyclic-module-record
         text: GetMethod; url: sec-getmethod
         text: ToBigInt64; url: #sec-tobigint64
-        text: BigInt; url: #sec-ecmascript-language-types-bigint-type
-        text: Cyclic Module Record; url: cyclic-module-record
     type: abstract-op
         text: CreateDataPropertyOrThrow; url: sec-createdatapropertyorthrow
         text: CreateMethodProperty; url: sec-createmethodproperty
@@ -1377,8 +1376,7 @@ WebAssembly modules can be used in a module graph with ECMAScript modules and So
 
 Note: While this specification is not yet merged into the main Wasm specification, since it defines both a Source Phase Imports integration and an evaluation/instance phase integration, implementations may choose to implement only the Source Phase Imports as its own smaller proposal without implementing the full evaluation/instance phase import support. In this case, the `ResolveExport` abstract operation should be implemented as returning null, and the `InitializeEnvironment` and `ExecuteModule` abstract operations implemented as unconditionally throwing a `SyntaxError` exception. This note will be removed when this proposal is upstreamed.
 
-<dfn export>WebAssembly Module Record</dfn>s are a subclass of [=Cyclic Module Record=] which contain WebAssembly code. WebAssembly Module Records have one additional internal slot:
-    * \[[WebAssemblyModule]] : a WebAssembly {{Module}} object
+<dfn export>WebAssembly Module Record</dfn>s are a subclass of [=Cyclic Module Record=] which contain WebAssembly code.
 
 <div algorithm>
 To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |bytes|, a Realm |realm| and object |hostDefined|, perform the following steps.
@@ -1393,8 +1391,9 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. Return {
       <!-- Abstract Module Records -->
       \[[Realm]]: |realm|,
-      \[[Environment]]: undefined,
-      \[[Namespace]]: undefined,
+      \[[Environment]]: ~empty~,
+      \[[Namespace]]: ~empty~,
+      \[[ModuleSource]]: |module|,
       \[[HostDefined]]: |hostDefined|,
       <!-- Cyclic Module Records -->
       \[[Status]]: "new",
@@ -1409,8 +1408,6 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
       \[[TopLevelCapability]]: ~empty~
       \[[AsyncParentModules]]: &laquo; &raquo;,
       \[[PendingAsyncDependencies]]: ~empty~,
-      <!-- WebAssembly Module Records -->
-      \[[WebAssemblyModule]]: |module|
     }.
 
 Note: From HTML, it's not observable when [=parse a WebAssembly module=] begins, so any work perfomed in compilation may be performed off-thread.
@@ -1419,7 +1416,7 @@ Note: From HTML, it's not observable when [=parse a WebAssembly module=] begins,
 <div algorithm>
 The <dfn>export name list</dfn> of a WebAssembly Module Record |record| is defined by the following algorithm:
 
-1. Let |module| be |record|'s \[[WebAssemblyModule]] internal slot.
+1. Let |module| be |record|'s \[[ModuleSource]] internal slot.
 1. Let |exports| be an empty [=list=].
 1. For each (|name|, <var ignore>type</var>) in [=module_exports=](|module|.\[[Module]])
     1. [=list/Append=] |name| to the end of |exports|.
@@ -1462,7 +1459,7 @@ WebAssembly Module Records have the following methods:
 <h3 id="module-execution">ExecuteModule ( [ |promiseCapability| ] ) Concrete Method</h3>
 1. Assert: |promiseCapability| was not provided.
 1. Let |record| be this WebAssembly Module Record.
-1. Let |module| be |record|.\[[WebAssemblyModule]].
+1. Let |module| be |record|.\[[ModuleSource]].
 1. Let |imports| be a new, empty [=map=].
 1. For each (|importedModuleName|, |name|, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
     1. If |imports|[|importedModuleName|] does not exist, set |imports|[|importedModuleName|] to a new, empty [=map=].
@@ -1481,15 +1478,6 @@ WebAssembly Module Records have the following methods:
     1. Perform ! |record|.\[[Environment]].InitializeBinding(|name|, ! Get(|instance|.\[[Exports]], |name|)).
 
     Note: exported bindings are left uninitialized, i.e., in TDZ.
-
-</div>
-
-<div algorithm=GetModuleSource>
-
-<h3 id="get-module-source">GetModuleSource ( ) Concrete Method</h3>
-1. Let |record| be this WebAssembly Module Record.
-1. Let |module| be |record|.\[[WebAssemblyModule]].
-1. Return |module|.
 
 </div>
 


### PR DESCRIPTION
This updates the spec to match the latest source phase imports proposal, which changed to using a `[[ModuleSource]]` slot fully defined in ECMA-262 in https://github.com/tc39/proposal-source-phase-imports/pull/69 (and the corresponding upstream PR).

As a result we can set the WebAssembly.Module directly into this slot without needing any custom slots or to provide the `GetModuleSource` concrete method.

We may also be able to upgrade `HostGetModuleSourceName` to rather be the new `HostGetModuleSourceModuleRecord`, which is separately tracking in https://github.com/tc39/proposal-source-phase-imports/pull/70.