### PR TITLE
Use updated HostGetModuleSourceModuleRecord host function

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -349,6 +349,7 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
 
     * \[[Module]] : a WebAssembly [=/module=]
     * \[[Bytes]] : the source bytes of \[[Module]].
+    * \[[ModuleRecord]] : the <a>WebAssembly Module Record</a> if this WebAssembly module is associated with one.
 
 <div algorithm>
   To <dfn>construct a WebAssembly module object</dfn> from a module |module| and source bytes |bytes|, perform the following steps:
@@ -356,6 +357,7 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
     1. Let |moduleObject| be a new {{Module}} object.
     1. Set |moduleObject|.\[[Module]] to |module|.
     1. Set |moduleObject|.\[[Bytes]] to |bytes|.
+    1. Set |moduleObject|.\[[ModuleRecord]] to null.
     1. Return |moduleObject|.
 </div>
 
@@ -1388,7 +1390,7 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, <var ignore>name</var>, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
     1. [=set/Append=] |moduleName| to |requestedModules|.
-1. Return {
+1. Let |moduleRecord| be {
       <!-- Abstract Module Records -->
       \[[Realm]]: |realm|,
       \[[Environment]]: ~empty~,
@@ -1409,6 +1411,8 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
       \[[AsyncParentModules]]: &laquo; &raquo;,
       \[[PendingAsyncDependencies]]: ~empty~,
     }.
+1. Set |module|.\[[ModuleRecord]] to |moduleRecord|.
+1. Return |moduleRecord|.
 
 Note: From HTML, it's not observable when [=parse a WebAssembly module=] begins, so any work perfomed in compilation may be performed off-thread.
 </div>
@@ -1440,6 +1444,13 @@ WebAssembly Module Records have the following methods:
 1. Let |record| be this WebAssembly Module Record.
 1. If the [=export name list=] of |record| contains |exportName|, return { \[[Module]]: |record|, \[[BindingName]]: |exportName| }.
 1. Otherwise, return null.
+
+</div>
+
+<div algorithm=GetModuleSourceKind>
+
+<h3 id="get-module-source-kind">GetModuleSourceKind ( ) Concrete Method</h3>
+1. Return "WebAssembly.Module".
 
 </div>
 
@@ -1481,9 +1492,38 @@ WebAssembly Module Records have the following methods:
 
 </div>
 
-<h3 id="hostgetmodulesourcename">HostGetModuleSourceName</h3>
-
-Hosts should implement [$HostGetModuleSourceName$] such that whenever a WebAssembly {{Module}} object is provided with a \[[Module]] internal slot, the string "<code data-x="">WebAssembly.Module</code>" is always returned.
+<h3 id="hostgetmodulesourcemodulerecord">HostGetModuleSourceModuleRecord ( |specifier| )</h3>
+1. If |specifier| is a WebAssembly {{Module}} object with a \[[Module]] internal slot,
+    1. If |specifier|.\[[Module]].\[[ModuleRecord]] is null,
+        1. Let |realm| be the current agent's realm record.
+        1. Let |requestedModules| be a set.
+        1. For each (|moduleName|, <var ignore>name</var>, <var ignore>type</var>) in [=module_imports=](|specifier|.\[[Module]]),
+            1. [=set/Append=] |moduleName| to |requestedModules|.
+        1. Let |moduleRecord| be {
+              <!-- Abstract Module Records -->
+              \[[Realm]]: |realm|,
+              \[[Environment]]: ~empty~,
+              \[[Namespace]]: ~empty~,
+              \[[ModuleSource]]: |module|,
+              \[[HostDefined]]: ~empty~,
+              <!-- Cyclic Module Records -->
+              \[[Status]]: "new",
+              \[[EvaluationError]]: undefined,
+              \[[DFSIndex]]: undefined,
+              \[[DFSAncestorIndex]]: undefined,
+              \[[RequestedModules]]: |requestedModules|,
+              \[[LoadedModules]]: &laquo; &raquo;,
+              \[[CycleRoot]]: ~empty~,
+              \[[HasTLA]]: false,
+              \[[AsyncEvaluation]]: false,
+              \[[TopLevelCapability]]: ~empty~
+              \[[AsyncParentModules]]: &laquo; &raquo;,
+              \[[PendingAsyncDependencies]]: ~empty~,
+            }.
+        1. Set |module|.\[[ModuleRecord]] to |moduleRecord|.
+        1. Return |moduleRecord|.
+    1. Return |specifier|.\[[Module]].\[[ModuleRecord]].
+1. Return ~not-a-source~.
 
 Note: See corresponding modifications to HTML in <a href="https://github.com/whatwg/html/pull/10380">PR #10380</a>.
 


### PR DESCRIPTION
This is an editorial change to update to the latest Source Phase Imports spec change refactoring `HostGetModuleSourceName` into `HostGetModuleSourceModuleRecord` per the upcoming ESM Phase Imports refactoring.

While this change is editorial here, when layered with the upcoming ESM Phase Imports proposal it implies the importability of `WebAssembly.Module` instances under dynamic import via `import(mod)` defined through its spec at https://tc39.es/proposal-esm-phase-imports/.

To avoid creating a cyclic module record for all WebAssembly.Module compilations, the module record is lazily populated for non source-phase modules only when this host hook is called. These semantics will also require a corresponding HTML spec adjustment to handle an empty `[[HostDefined]]` on the module record as these modules aren't associated with script records.