### PR TITLE
Import attribute support

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1389,10 +1389,10 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. Note: When integrating with the JS String Builtins proposal, |builtinSetNames| should be passed in the following step as « "js-strings" » and |importedStringModule| as null.
 1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
 1. Let |requestedModules| be a set.
-1. For each (|moduleName|, |name|, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
+1. For each (|moduleName|, |name|, |type|) in [=module_imports=](|module|.\[[Module]]),
     1. Note: The following step only applies when integrating with the JS String Builtins proposal.
-    1. If [=Find a builtin=] with (|moduleName|, |name|) and builtins |module|.\[[BuiltinSets]] is not null, then [=iteration/continue=].
-        1. [=set/Append=] |moduleName| to |requestedModules|.
+    1. If [=Find a builtin=] with (|moduleName|, |name|, |type|) and builtins |module|.\[[BuiltinSets]] is not null, then [=iteration/continue=].
+    1. [=set/Append=] |moduleName| to |requestedModules|.
 1. Let |moduleRecord| be {
       <!-- Abstract Module Records -->
       \[[Realm]]: |realm|,

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1431,6 +1431,7 @@ Note: From HTML, it's not observable when [=parse a WebAssembly module=] begins,
 1. If |wasmBuiltinAttribute| is equal to "none",
     1. Return null.
 1. Throw a {{TypeError}} exception.
+
 </div>
 
 <div algorithm>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1388,7 +1388,7 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, <var ignore>name</var>, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
     1. If |moduleName| starts with the string "wasm:",
-        1. Throw a {{LinkError}} exception.
+        1. Throw a {{CompileError}} exception.
     1. [=set/Append=] |moduleName| to |requestedModules|.
 1. Return {
       <!-- Abstract Module Records -->

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1386,7 +1386,8 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
 1. [=Compile a WebAssembly module|Compile the WebAssembly module=] |stableBytes| and store the result as |module|.
 1. If |module| is [=error=], throw a {{CompileError}} exception.
-1. Note: When integrating with the JS String Builtins proposal, |builtinSetNames| should be passed in the following step as « "js-string" » and |importedStringModule| as null.
+1. Let |builtinSetNames| be « |wasmBuiltinAttribute| » if |wasmBuiltinAttribute| is defined and « » otherwise.
+1. Note: When integrating with the JS String Builtins proposal, |builtinSetNames| should be passed in the following step as |builtinSetNames|, and |importedStringModule| as null.
 1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, |name|, |type|) in [=module_imports=](|module|.\[[Module]]),

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1410,7 +1410,7 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
       \[[PendingAsyncDependencies]]: ~empty~,
     }.
 
-Node: When integrating with the JS String Builtins proposal, "<code data-x="">builtins: ["js-string"]</code>" should be provided in the WebAssembly compilation options, with the corresponding builtin names permitted.
+Note: When integrating with the JS String Builtins proposal, "<code data-x="">builtins: ["js-string"]</code>" should be provided in the WebAssembly compilation options, with the corresponding builtin names permitted.
 
 Note: From HTML, it's not observable when [=parse a WebAssembly module=] begins, so any work perfomed in compilation may be performed off-thread.
 </div>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1388,8 +1388,9 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. If |module| is [=error=], throw a {{CompileError}} exception.
 1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
 1. Let |requestedModules| be a set.
-1. For each (|moduleName|, <var ignore>name</var>, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
-    1. If |moduleName| is not equal to "wasm:js-strings",
+1. For each (|moduleName|, |name|, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
+    1. Note: The following step only applies when integrating with the JS String Builtins proposal.
+    1. If [=Find a builtin=] with (|moduleName|, |name|) and builtins |module|.\[[BuiltinSets]] is not null, then [=iteration/continue=].
         1. [=set/Append=] |moduleName| to |requestedModules|.
 1. Let |moduleRecord| be {
       <!-- Abstract Module Records -->
@@ -1415,7 +1416,7 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. Set |module|.\[[ModuleRecord]] to |moduleRecord|.
 1. Return |moduleRecord|.
 
-Note: When integrating with the JS String Builtins proposal, "<code data-x="">builtins: ["js-string"]</code>" should be provided in the WebAssembly compilation options.
+Note: While this spec is not currently merged with the JS String Builtins proposal, the steps to take when merging are noted here for reference.
 
 Note: From HTML, it's not observable when [=parse a WebAssembly module=] begins, so any work perfomed in compilation may be performed off-thread.
 </div>
@@ -1476,7 +1477,8 @@ WebAssembly Module Records have the following methods:
 1. Let |module| be |record|.\[[ModuleSource]].
 1. Let |imports| be a new, empty [=map=].
 1. For each (|importedModuleName|, |name|, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
-    1. If |moduleName| is equal to "wasm:js-strings", then continue.
+    1. Note: The following step only applies when integrating with the JS String Builtins proposal.
+    1. If [=Find a builtin=] with (|importedModuleName|, |name|) and builtins |module|.\[[BuiltinSets]] is not null, then [=iteration/continue=].
     1. If |imports|[|importedModuleName|] does not exist, set |imports|[|importedModuleName|] to a new, empty [=map=].
     1. Let |importedModule| be [$GetImportedModule$](|record|, |importedModuleName|).
     1. Let |value| be ? |importedModule|.\[[Environment]].GetBindingValue(|name|, true).

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1387,6 +1387,8 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, <var ignore>name</var>, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
+    1. If |moduleName| starts with the string "wasm:",
+        1. Throw a {{LinkError}} exception.
     1. [=set/Append=] |moduleName| to |requestedModules|.
 1. Return {
       <!-- Abstract Module Records -->
@@ -1409,6 +1411,8 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
       \[[AsyncParentModules]]: &laquo; &raquo;,
       \[[PendingAsyncDependencies]]: ~empty~,
     }.
+
+Node: When integrating with the JS String Builtins proposal, "<code data-x="">builtins: ["js-string"]</code>" should be provided in the above WebAssembly compilation options, with the corresponding builtin names permitted.
 
 Note: From HTML, it's not observable when [=parse a WebAssembly module=] begins, so any work perfomed in compilation may be performed off-thread.
 </div>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1381,12 +1381,12 @@ Note: While this specification is not yet merged into the main Wasm specificatio
 <dfn export>WebAssembly Module Record</dfn>s are a subclass of [=Cyclic Module Record=] which contain WebAssembly code.
 
 <div algorithm>
-To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |bytes|, a Realm |realm| and object |hostDefined|, perform the following steps.
+To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |bytes|, a Realm |realm|, an optional string |wasmBuiltinAttribute| and object |hostDefined|, perform the following steps.
 
 1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
 1. [=Compile a WebAssembly module|Compile the WebAssembly module=] |stableBytes| and store the result as |module|.
 1. If |module| is [=error=], throw a {{CompileError}} exception.
-1. Note: When integrating with the JS String Builtins proposal, |builtinSetNames| should be passed in the following step as « "js-strings" » and |importedStringModule| as null.
+1. Note: When integrating with the JS String Builtins proposal, |builtinSetNames| should be passed in the following step as « "js-string" » and |importedStringModule| as null.
 1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, |name|, |type|) in [=module_imports=](|module|.\[[Module]]),
@@ -1420,6 +1420,16 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 Note: While this spec is not currently merged with the JS String Builtins proposal, the steps to take when merging are noted here for reference.
 
 Note: From HTML, it's not observable when [=parse a WebAssembly module=] begins, so any work perfomed in compilation may be performed off-thread.
+</div>
+
+<div algorithm>
+<dfn>Validate and canonicalize the WebAssembly builtin attribute</dfn> given an optional string |wasmBuiltinAttribute| is defined by the following algorithm:
+
+1. If |wasmBuiltinAttribute| is not defined, or if it is equal to "all" or "js-string",
+    1. Return "js-string".
+1. If |wasmBuiltinAttribute| is equal to "none",
+    1. Return null.
+1. Throw a {{TypeError}} exception.
 </div>
 
 <div algorithm>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1387,7 +1387,8 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, <var ignore>name</var>, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
-    1. [=set/Append=] |moduleName| to |requestedModules|.
+    1. If |moduleName| does not start with the builtin string prefix "wasm:",
+        1. [=set/Append=] |moduleName| to |requestedModules|.
 1. Return {
       <!-- Abstract Module Records -->
       \[[Realm]]: |realm|,
@@ -1464,6 +1465,7 @@ WebAssembly Module Records have the following methods:
 1. Let |module| be |record|.\[[ModuleSource]].
 1. Let |imports| be a new, empty [=map=].
 1. For each (|importedModuleName|, |name|, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
+    1. If |moduleName| starts with the string "wasm:", then continue.
     1. If |imports|[|importedModuleName|] does not exist, set |imports|[|importedModuleName|] to a new, empty [=map=].
     1. Let |importedModule| be [$GetImportedModule$](|record|, |importedModuleName|).
     1. Let |value| be ? |importedModule|.\[[Environment]].GetBindingValue(|name|, true).

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1387,9 +1387,8 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, <var ignore>name</var>, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
-    1. If |moduleName| starts with the string "wasm:",
-        1. Throw a {{CompileError}} exception.
-    1. [=set/Append=] |moduleName| to |requestedModules|.
+    1. If |moduleName| does not start with the builtin string prefix "wasm:",
+        1. [=set/Append=] |moduleName| to |requestedModules|.
 1. Return {
       <!-- Abstract Module Records -->
       \[[Realm]]: |realm|,
@@ -1412,7 +1411,7 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
       \[[PendingAsyncDependencies]]: ~empty~,
     }.
 
-Node: When integrating with the JS String Builtins proposal, "<code data-x="">builtins: ["js-string"]</code>" should be provided in the above WebAssembly compilation options, with the corresponding builtin names permitted.
+Node: When integrating with the JS String Builtins proposal, "<code data-x="">builtins: ["js-string"]</code>" should be provided in the WebAssembly compilation options, with the corresponding builtin names permitted.
 
 Note: From HTML, it's not observable when [=parse a WebAssembly module=] begins, so any work perfomed in compilation may be performed off-thread.
 </div>
@@ -1466,6 +1465,9 @@ WebAssembly Module Records have the following methods:
 1. Let |module| be |record|.\[[ModuleSource]].
 1. Let |imports| be a new, empty [=map=].
 1. For each (|importedModuleName|, |name|, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
+    1. If |moduleName| starts with the string "wasm:",
+        Note: when integrating with the JS String Builtins proposal, string builtins should be excluded from erroring here.
+        1. Throw a {{LinkError}} exception.
     1. If |imports|[|importedModuleName|] does not exist, set |imports|[|importedModuleName|] to a new, empty [=map=].
     1. Let |importedModule| be [$GetImportedModule$](|record|, |importedModuleName|).
     1. Let |value| be ? |importedModule|.\[[Environment]].GetBindingValue(|name|, true).

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1387,7 +1387,7 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, <var ignore>name</var>, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
-    1. If |moduleName| does not start with the builtin string prefix "wasm:",
+    1. If |moduleName| is not equal to "wasm:js-strings",
         1. [=set/Append=] |moduleName| to |requestedModules|.
 1. Return {
       <!-- Abstract Module Records -->
@@ -1465,7 +1465,7 @@ WebAssembly Module Records have the following methods:
 1. Let |module| be |record|.\[[ModuleSource]].
 1. Let |imports| be a new, empty [=map=].
 1. For each (|importedModuleName|, |name|, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
-    1. If |moduleName| starts with the string "wasm:", then continue.
+    1. If |moduleName| is equal to "wasm:js-strings", then continue.
     1. If |imports|[|importedModuleName|] does not exist, set |imports|[|importedModuleName|] to a new, empty [=map=].
     1. Let |importedModule| be [$GetImportedModule$](|record|, |importedModuleName|).
     1. Let |value| be ? |importedModule|.\[[Environment]].GetBindingValue(|name|, true).

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1386,6 +1386,7 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
 1. [=Compile a WebAssembly module|Compile the WebAssembly module=] |stableBytes| and store the result as |module|.
 1. If |module| is [=error=], throw a {{CompileError}} exception.
+1. Note: When integrating with the JS String Builtins proposal, |builtinSetNames| should be passed in the following step as « "js-strings" » and |importedStringModule| as null.
 1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, |name|, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1387,8 +1387,7 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, <var ignore>name</var>, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
-    1. If |moduleName| does not start with the builtin string prefix "wasm:",
-        1. [=set/Append=] |moduleName| to |requestedModules|.
+    1. [=set/Append=] |moduleName| to |requestedModules|.
 1. Return {
       <!-- Abstract Module Records -->
       \[[Realm]]: |realm|,
@@ -1465,9 +1464,6 @@ WebAssembly Module Records have the following methods:
 1. Let |module| be |record|.\[[ModuleSource]].
 1. Let |imports| be a new, empty [=map=].
 1. For each (|importedModuleName|, |name|, <var ignore>type</var>) in [=module_imports=](|module|.\[[Module]]),
-    1. If |moduleName| starts with the string "wasm:",
-        Note: when integrating with the JS String Builtins proposal, string builtins should be excluded from erroring here.
-        1. Throw a {{LinkError}} exception.
     1. If |imports|[|importedModuleName|] does not exist, set |imports|[|importedModuleName|] to a new, empty [=map=].
     1. Let |importedModule| be [$GetImportedModule$](|record|, |importedModuleName|).
     1. Let |value| be ? |importedModule|.\[[Environment]].GetBindingValue(|name|, true).


### PR DESCRIPTION
This is part of implementing https://github.com/WebAssembly/esm-integration/issues/99, the other part would need to be on the HTML integration side.

This just defines a new function "Validate and canonicalize the WebAssembly builtin attribute", which performs the canonicalizations listed in #99 to avoid duplicate module records.

In the HTML spec, it would then need to call into this canonicalization on the chosen attribute name (also a decision to be made in HTML), and then pass the corresponding string back into the the parse a WebAssembly module step.