### PR TITLE
ESM Phase Imports import() & new Worker() support for WA.Module

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -2327,7 +2327,7 @@ To <dfn export>create a WebAssembly Module Record</dfn> given a WebAssembly modu
       \[[Realm]]: |realm|,
       \[[Environment]]: ~empty~,
       \[[Namespace]]: ~empty~,
-      \[[ModuleSource]]: |module|,
+      \[[ModuleSource]]: |moduleObject|,
       \[[HostDefined]]: |hostDefined|,
       <!-- Cyclic Module Records -->
       \[[Status]]: "new",
@@ -2346,7 +2346,7 @@ To <dfn export>create a WebAssembly Module Record</dfn> given a WebAssembly modu
 1. Set |moduleObject|.\[[ModuleRecord]] to |moduleRecord|.
 1. Return |moduleRecord|.
 
-Note: From HTML, it's not observable when [=parse a WebAssembly module=] begins, so any work perfomed in compilation may be performed off-thread.
+Note: From HTML, it's not observable when [=create a WebAssembly Module Record=] begins, so any work perfomed in compilation may be performed off-thread.
 </div>
 
 <div algorithm>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -2384,6 +2384,17 @@ WebAssembly Module Records have the following methods:
 
 </div>
 
+<div algorithm=ModuleSourcesEqual>
+
+<h3 id="module-sources-equal">ModuleSourcesEqual ( |otherRecord| ) Concrete Method</h3>
+1. If |otherRecord| is not a WebAssemly Module Record, return false.
+1. Let |record| be this WebAssembly Module Record.
+1. Let |module| be |record|.\[[ModuleSource]].
+1. Let |otherModule| be |otherRecord|.\[[ModuleSource]].
+1. Return true if |module|.\[[Bytes]] is equal to |otherModule|.\[[Bytes]], and false otherwise.
+
+</div>
+
 <div algorithm=GetModuleSourceKind>
 
 <h3 id="get-module-source-kind">GetModuleSourceKind ( ) Concrete Method</h3>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -809,6 +809,7 @@ In addition, the interface object for {{Module}} must have as its \[[Prototype]]
     1. Set **this**.\[[Bytes]] to |stableBytes|.
     1. Set **this**.\[[BuiltinSets]] to |builtinSetNames|.
     1. Set **this**.\[[ImportedStringModule]] to |importedStringModule|.
+    1. Set **this**.\[[ModuleRecord]] to null.
 
 Note: Some implementations enforce a size limitation on |bytes|. Use of this API is discouraged, in favor of asynchronous APIs.
 </div>
@@ -2307,7 +2308,7 @@ Note: While this specification is not yet merged into the main Wasm specificatio
 <div algorithm>
 To <dfn export>create a WebAssembly Module Record</dfn> given a WebAssembly module object |moduleObject|, a Realm |realm| and object |hostDefined|, perform the following steps.
 
-1. Assert: |moduleObject|.\[[ModuleRecord]] is not defined.
+1. Assert: |moduleObject|.\[[ModuleRecord]] is null.
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, <var ignore>name</var>, <var ignore>type</var>) in [=module_imports=](|moduleObject|.\[[Module]]),
     1. If |moduleName| starts with the prefix "wasm-js:",

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -2305,16 +2305,11 @@ Note: While this specification is not yet merged into the main Wasm specificatio
 <dfn export>WebAssembly Module Record</dfn>s are a subclass of [=Cyclic Module Record=] which contain WebAssembly code.
 
 <div algorithm>
-To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |bytes|, a Realm |realm| and object |hostDefined|, perform the following steps.
+To <dfn export>create a WebAssembly Module Record</dfn> given a WebAssembly module object |moduleObject|, a Realm |realm| and object |hostDefined|, perform the following steps.
 
-1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
-1. [=Compile a WebAssembly module|Compile the WebAssembly module=] |stableBytes| and store the result as |module|.
-1. If |module| is [=error=], throw a {{CompileError}} exception.
-1. Let |builtinSetNames| be « "js-string" ».
-1. Let |importedStringModule| be "wasm:js/string-constants".
-1. [=Construct a WebAssembly module object=] from |module|, |bytes|, |builtinSetNames| and |importedStringModule|, and let |module| be the result.
+1. Assert: |moduleObject|.\[[ModuleRecord]] is not defined.
 1. Let |requestedModules| be a set.
-1. For each (|moduleName|, |name|, |type|) in [=module_imports=](|module|.\[[Module]]),
+1. For each (|moduleName|, <var ignore>name</var>, <var ignore>type</var>) in [=module_imports=](|moduleObject|.\[[Module]]),
     1. If |moduleName| starts with the prefix "wasm-js:",
         1. Throw a {{LinkError}} exception.
     1. If |name| starts with the prefix "wasm:" or "wasm-js:",
@@ -2348,7 +2343,7 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
       \[[AsyncParentModules]]: &laquo; &raquo;,
       \[[PendingAsyncDependencies]]: ~empty~,
     }.
-1. Set |module|.\[[ModuleRecord]] to |moduleRecord|.
+1. Set |moduleObject|.\[[ModuleRecord]] to |moduleRecord|.
 1. Return |moduleRecord|.
 
 Note: From HTML, it's not observable when [=parse a WebAssembly module=] begins, so any work perfomed in compilation may be performed off-thread.

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -71,7 +71,7 @@ urlPrefix: https://html.spec.whatwg.org/; spec: HTML; type: dfn
     text: default script fetch options; url: #default-script-fetch-options
     text: current settings object; url: #current-settings-object
     text: CORS-same-origin; url: #cors-same-origin
-    text: creating a WebAssembly Module Script; url: #creating-a-webassembly-module-script
+    text: create a WebAssembly Module Script; url: #creating-a-webassembly-module-script
 url:https://fetch.spec.whatwg.org/#concept-body-consume-body;text:consume body;type:dfn;spec:FETCH
 url:https://w3c.github.io/webappsec-secure-contexts/#environment-settings-object-contextually-secure; text:contextually secure; type: dfn; spec: SECURECONTEXTS
 </pre>

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -66,7 +66,11 @@ urlPrefix: https://webassembly.github.io/spec/js-api/; spec: WASMJS
         text: asynchronously compile a webassembly module; url: #asynchronously-compile-a-webassembly-module
         text: instantiate a promise of a module; url: #instantiate-a-promise-of-a-module
         text: Exported Function; url: #exported-function
-url:https://html.spec.whatwg.org/#cors-same-origin;text:CORS-same-origin;type:dfn;spec:HTML
+urlPrefix: https://html.spec.whatwg.org/; spec: HTML; type: dfn
+    text: rooted source; url: #concept-script-rooted-source
+    text: default script fetch options; url: #default-script-fetch-options
+    text: current settings object; url: #current-settings-object
+    text: CORS-same-origin; url: #cors-same-origin
 url:https://fetch.spec.whatwg.org/#concept-body-consume-body;text:consume body;type:dfn;spec:FETCH
 url:https://w3c.github.io/webappsec-secure-contexts/#environment-settings-object-contextually-secure; text:contextually secure; type: dfn; spec: SECURECONTEXTS
 </pre>
@@ -167,7 +171,7 @@ The [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
             1. Set |serialized|.\[[Rooted]] to true.
 
-            1. Set |serialized|.\[[BaseURL]] to |moduleScript|'s <span data-x"concept-script-base-url">base URL</span>.
+            1. Set |serialized|.\[[BaseURL]] to |moduleScript|'s [=base URL=].
 
     1. If |rooted| is false,
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -71,6 +71,7 @@ urlPrefix: https://html.spec.whatwg.org/; spec: HTML; type: dfn
     text: default script fetch options; url: #default-script-fetch-options
     text: current settings object; url: #current-settings-object
     text: CORS-same-origin; url: #cors-same-origin
+    text: creating a WebAssembly Module Script; url: #creating-a-webassembly-module-script
 url:https://fetch.spec.whatwg.org/#concept-body-consume-body;text:consume body;type:dfn;spec:FETCH
 url:https://w3c.github.io/webappsec-secure-contexts/#environment-settings-object-contextually-secure; text:contextually secure; type: dfn; spec: SECURECONTEXTS
 </pre>
@@ -181,32 +182,27 @@ The [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
 The [=deserialization steps=], given |serialized|, |value|, and |targetRealm| are:
 
+    1. If |targetRealm|'s corresponding [=agent cluster=] is not |serialized|.\[[AgentCluster]], then throw a "<a exception>DataCloneError</a>" {{DOMException}}.
+
     1. Let |bytes| be the [=sub-deserialization=] of |serialized|.\[[Bytes]].
+
+    1. Set |value|.\[[Bytes]] to |bytes|.
+    
+    1. [=Compile a WebAssembly module=] from |bytes| and set |value|.\[[Module]] to the result.
+
+    1. Assert: there was no compile error as this same module was previously compiled successfully.
 
     1. Let |rooted| be the [=sub-deserialization=] of |serialized|.\[[Rooted]].
 
-    1. Let |baseURL| be the [=sub-deserialization=] of |serialized|.\[[BaseURL]].
+    1. If |rooted| is true then,
 
-    1. If |rooted| is false then,
-
-        1. Set |value|.\[[Bytes]] to |bytes|.
-
-        1. If |targetRealm|'s corresponding [=agent cluster=] is not |serialized|.\[[AgentCluster]], then throw a "<a exception>DataCloneError</a>" {{DOMException}}.
-
-        1. [=Compile a WebAssembly module=] from |bytes| and set |value|.\[[Module]] to the result.
-
-    1. Otherwise,
+        1. Let |baseURL| be the [=sub-deserialization=] of |serialized|.\[[BaseURL]].
 
         1. Let |settings| be the [=current settings object=].
 
         1. Let |fetchOptions| be the [=default script fetch options=].
 
-        1. Let |moduleScript| be the result of [=creating a WebAssembly module script=] given |bytes|, |settings|, |baseURL|, |fetchOptions|, true.
-
-        1. [=Parse a WebAssembly module=] given |bytes|, [=current Realm=] and |moduleScript| and set |value|.\[[Module]] to the result.
-
-    1. Assert: there was no compile error as this same module was previously compiled successfully.
-
+        1. Let <var ignore>moduleScript</var> be the result of [=creating a WebAssembly module script=] given |value|, |settings|, |baseURL|, |fetchOptions|, true.
 
 Engines should attempt to share/reuse internal compiled code when performing
 a structured serialization, although in corner cases like CPU upgrade or browser

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -202,7 +202,7 @@ The [=deserialization steps=], given |serialized|, |value|, and |targetRealm| ar
 
         1. Let |fetchOptions| be the [=default script fetch options=].
 
-        1. Let <var ignore>moduleScript</var> be the result of [=creating a WebAssembly module script=] given |value|.\[[Module]], |settings|, |baseURL|, |fetchOptions|, true.
+        1. [=Create a WebAssembly module script=] given |value|.\[[Module]], |settings|, |baseURL|, |fetchOptions|, and true.
 
 Engines should attempt to share/reuse internal compiled code when performing
 a structured serialization, although in corner cases like CPU upgrade or browser

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -162,7 +162,7 @@ The [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
     1. Let |rooted| be false.
 
-    1. If |value|.\[[ModuleRecord]] is not null and |value|.\[[ModuleRecord]].\[[HostDefined]] is not empty,
+    1. If |value|.\[[ModuleRecord]] is not null and |value|.\[[ModuleRecord]].\[[HostDefined]] is not empty:
 
         1. Let |moduleScript| be |value|.\[[ModuleRecord]].\[[HostDefined]].
 
@@ -174,7 +174,7 @@ The [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
             1. Set |serialized|.\[[BaseURL]] to |moduleScript|'s [=base URL=].
 
-    1. If |rooted| is false,
+    1. If |rooted| is false:
 
         1. Set |serialized|.\[[Rooted]] to false.
 
@@ -194,7 +194,7 @@ The [=deserialization steps=], given |serialized|, |value|, and |targetRealm| ar
 
     1. Let |rooted| be the [=sub-deserialization=] of |serialized|.\[[Rooted]].
 
-    1. If |rooted| is true then,
+    1. If |rooted| is true:
 
         1. Let |baseURL| be the [=sub-deserialization=] of |serialized|.\[[BaseURL]].
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -155,15 +155,54 @@ The [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
     1. Set |serialized|.\[[AgentCluster]] to the [=current Realm=]'s corresponding [=agent cluster=].
 
+    1. Let |rooted| be false.
+
+    1. If |value|.\[[ModuleRecord]] is not empty and |value|.\[[ModuleRecord]].\[[HostDefined]] is not empty,
+
+        1. Let |moduleScript| be |value|.\[[ModuleRecord]].\[[HostDefined]].
+
+        1. Set |rooted| to |moduleScript|'s [=rooted source=] boolean.
+
+        1. If |rooted| is true then,
+
+            1. Set |serialized|.\[[Rooted]] to true.
+
+            1. Set |serialized|.\[[BaseURL]] to |moduleScript|'s <span data-x"concept-script-base-url">base URL</span>.
+
+    1. If |rooted| is false,
+
+        1. Set |serialized|.\[[Rooted]] to false.
+
+        1. Set |serialized|.\[[BaseURL]] to null.
+
 The [=deserialization steps=], given |serialized|, |value|, and |targetRealm| are:
 
     1. Let |bytes| be the [=sub-deserialization=] of |serialized|.\[[Bytes]].
 
-    1. Set |value|.\[[Bytes]] to |bytes|.
+    1. Let |rooted| be the [=sub-deserialization=] of |serialized|.\[[Rooted]].
 
-    1. If |targetRealm|'s corresponding [=agent cluster=] is not |serialized|.\[[AgentCluster]], then throw a "<a exception>DataCloneError</a>" {{DOMException}}.
+    1. Let |baseURL| be the [=sub-deserialization=] of |serialized|.\[[BaseURL]].
 
-    1. [=Compile a WebAssembly module=] from |bytes| and set |value|.\[[Module]] to the result.
+    1. If |rooted| is false then,
+
+        1. Set |value|.\[[Bytes]] to |bytes|.
+
+        1. If |targetRealm|'s corresponding [=agent cluster=] is not |serialized|.\[[AgentCluster]], then throw a "<a exception>DataCloneError</a>" {{DOMException}}.
+
+        1. [=Compile a WebAssembly module=] from |bytes| and set |value|.\[[Module]] to the result.
+
+    1. Otherwise,
+
+        1. Let |settings| be the [=current settings object=].
+
+        1. Let |fetchOptions| be the [=default script fetch options=].
+
+        1. Let |moduleScript| be the result of [=creating a WebAssembly module script=] given |bytes|, |settings|, |baseURL|, |fetchOptions|, true.
+
+        1. [=Parse a WebAssembly module=] given |bytes|, [=current Realm=] and |moduleScript| and set |value|.\[[Module]] to the result.
+
+    1. Assert: there was no compile error as this same module was previously compiled successfully.
+
 
 Engines should attempt to share/reuse internal compiled code when performing
 a structured serialization, although in corner cases like CPU upgrade or browser

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -162,7 +162,7 @@ The [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
     1. Let |rooted| be false.
 
-    1. If |value|.\[[ModuleRecord]] is not empty and |value|.\[[ModuleRecord]].\[[HostDefined]] is not empty,
+    1. If |value|.\[[ModuleRecord]] is not null and |value|.\[[ModuleRecord]].\[[HostDefined]] is not empty,
 
         1. Let |moduleScript| be |value|.\[[ModuleRecord]].\[[HostDefined]].
 
@@ -202,7 +202,7 @@ The [=deserialization steps=], given |serialized|, |value|, and |targetRealm| ar
 
         1. Let |fetchOptions| be the [=default script fetch options=].
 
-        1. Let <var ignore>moduleScript</var> be the result of [=creating a WebAssembly module script=] given |value|, |settings|, |baseURL|, |fetchOptions|, true.
+        1. Let <var ignore>moduleScript</var> be the result of [=creating a WebAssembly module script=] given |value|.\[[Module]], |settings|, |baseURL|, |fetchOptions|, true.
 
 Engines should attempt to share/reuse internal compiled code when performing
 a structured serialization, although in corner cases like CPU upgrade or browser


### PR DESCRIPTION
This implements the [ESM Phase Imports](https://github.com/tc39/proposal-esm-phase-imports) proposal, which in turn allows Wasm to define support for `new Worker(module)` and `import(module)` where `module` is an instance of `WebAssembly.Module`.

The corresponding HTML integration PR is available in https://github.com/whatwg/html/pull/11152.

We carefully define the difference between rooted and unrooted modules (those checked in the registry by the source phase, and those that are dynamically compiled with user sources / "evalish"), and then we define registry identity and include the URL in the transfer process for rooted modules.

Registry identity in the ESM Phase Imports proposal is based on the `ModuleSourcesEqual` concrete method which is implemented for WebAssembly Module Record allowing `import(module) === import(module)` equality for rooted sources and through structured clone transfer. For more info, this topic has been covered extensively in the last TC39 meetings for the ESM Phase Imports proposal.