### PR TITLE
Namespace unwrapping support in JS API as a follow-up to direct global exports

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -390,7 +390,7 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
     1. [=list/iterate|For each=] (|moduleName|, |componentName|, |externtype|) of [=module_imports=](|module|),
         1. Let |o| be [=?=] [$Get$](|importObject|, |moduleName|).
         1. If |o| [=is not an Object=], throw a {{TypeError}} exception.
-        1. If |o| [=is a Module namespace exotic object=] then,
+        1. If |o| [=is a Module Namespace exotic object=] then,
             1. Let |binding| be [=?=] |o|.\[[Module]].ResolveExport(|componentName|).
             1. Let |module| be |binding|.\[[Module]].
             1. If |module| is a [=WebAssembly Module Record=] and |binding|.\[[BindingName]] is not ~NAMESPACE~ then,

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -80,6 +80,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: Cyclic Module Record; url: cyclic-module-record
         text: GetMethod; url: sec-getmethod
         text: ToBigInt64; url: #sec-tobigint64
+        text: Module Namespace exotic object; url: #sec-module-namespace-exotic-objects
     type: abstract-op
         text: CreateDataPropertyOrThrow; url: sec-createdatapropertyorthrow
         text: CreateMethodProperty; url: sec-createmethodproperty
@@ -389,6 +390,16 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
     1. [=list/iterate|For each=] (|moduleName|, |componentName|, |externtype|) of [=module_imports=](|module|),
         1. Let |o| be [=?=] [$Get$](|importObject|, |moduleName|).
         1. If |o| [=is not an Object=], throw a {{TypeError}} exception.
+        1. If |o| [=is a Module namespace exotic object=] then,
+            1. Let |binding| be [=?=] |o|.\[[Module]].ResolveExport(|componentName|).
+            1. Let |module| be |binding|.\[[Module]].
+            1. If |module| is a [=WebAssembly Module Record=] and |binding|.\[[BindingName]] is not ~NAMESPACE~ then,
+                1. Let |moduleSource| be |module|.\[[ModuleSource]].
+                1. Let |importtype| be the value of |type| for the element (|binding|.\[[BindingName]], |type|) in [=module_exports=](|moduleSource|.\[[Module]]).
+                1. If |importtype| is not an [=extern subtype=] of |externtype|, throw a {{LinkError}} exception.
+                    1. Let |externval| be [=instance_export=](|module|.\[[Instance]], |binding|.\[[BindingName]]).
+                    1. [=list/Append=] |externval| to |imports|.
+                    1. Break.
         1. Let |v| be [=?=] [$Get$](|o|, |componentName|).
         1. If |externtype| is of the form [=func=] |functype|,
             1. If [$IsCallable$](|v|) is false, throw a {{LinkError}} exception.


### PR DESCRIPTION
This is an addition to https://github.com/WebAssembly/esm-integration/pull/104 (and based to that PR) that was brought up when this was discussed at the 25.03 Wasm CG meeting.

Specifically, Andreas Rossberg mentioned that having global instance bindings inaccessible for further use in the JS API could be overly restrictive.

To resolve that issue, this PR applies similar logic to what we do in the ESM binding logic but at the JS API level instead, keeping the APIs more in line. When a module namespace is passed on the importObj in the `WebAssembly.instantiate` API, we internally unwrap any WebAssembly global from the namespace when one is found.

The added checks somewhat repeat what we have for bindings on the WebAssembly module record already, so could be split out into a shared function if going this approach. The overall distinction between the ESM and JS API in operating on module records versus namespaces still seems to warrant the overall logic separation to me though.

//cc @rossberg, review very welcome as well, and if we have support for this change I can then look to merge it in with #104 and refactor some duplication.