### PR TITLE
Instance lookup function for Wasm Namespaces

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -539,7 +539,7 @@ The verification of WebAssembly type requirements is deferred to the
 
 <div algorithm>
   The <dfn method for="WebAssembly">namespaceInstance(|namespace|)</dfn> method, when invoked, performs the following steps:
-    1. If |namespace| is not a [=is a Module Namespace exotic object=], [=throw=] a {{TypeError}} exception.
+    1. If |namespace| is not a [=Module Namespace exotic object=], [=throw=] a {{TypeError}} exception.
     1. If |namespace|.\[[Module]] is not a [=WebAssembly Module Record=], [=throw=] a {{TypeError}} exception.
     1. Let |module| be |namespace|.\[[Module]].
     1. Return |module|.\[[Instance]].

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -651,7 +651,7 @@ Note: The use of this synchronous API is discouraged, as some implementations so
 </div>
 
 <div algorithm>
-    The <dfn method for="Instance">namespaceInstance(|moduleNamespace|)</dfn> method, when invoked, performs the following steps:
+    The <dfn method for="Instance">namespaceInstance(|namespace|)</dfn> method, when invoked, performs the following steps:
     1. Assert: |namespace| is a [=Module Namespace exotic object=].
     1. If |namespace|.\[[Module]] is not a [=WebAssembly Module Record=], [=throw=] a {{TypeError}} exception.
     1. Let |module| be |namespace|.\[[Module]].

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -319,8 +319,6 @@ namespace WebAssembly {
 
     Promise&lt;Instance> instantiate(
         Module moduleObject, optional object importObject);
-
-    Instance namespaceInstance(ModuleNamespace namespace);
 };
 </pre>
 
@@ -537,14 +535,6 @@ The verification of WebAssembly type requirements is deferred to the
     1. [=asynchronously instantiate a WebAssembly module|Asynchronously instantiate the WebAssembly module=] |moduleObject| importing |importObject|, and return the result.
 </div>
 
-<div algorithm>
-  The <dfn method for="WebAssembly">namespaceInstance(|namespace|)</dfn> method, when invoked, performs the following steps:
-    1. If |namespace| is not a [=Module Namespace exotic object=], [=throw=] a {{TypeError}} exception.
-    1. If |namespace|.\[[Module]] is not a [=WebAssembly Module Record=], [=throw=] a {{TypeError}} exception.
-    1. Let |module| be |namespace|.\[[Module]].
-    1. Return |module|.\[[Instance]].
-</div>
-
 Note: A follow-on streaming API is documented in the <a href="https://webassembly.github.io/spec/web-api/index.html">WebAssembly Web API</a>.
 
 <h3 id="modules">Modules</h3>
@@ -642,6 +632,7 @@ Note: Some implementations enforce a size limitation on |bytes|. Use of this API
 interface Instance {
   constructor(Module module, optional object importObject);
   readonly attribute object exports;
+  static Instance namespaceInstance(ModuleNamespace moduleNamespace);
 };
 </pre>
 
@@ -657,6 +648,14 @@ Note: The use of this synchronous API is discouraged, as some implementations so
 
 <div algorithm>
     The getter of the <dfn attribute for="Instance">exports</dfn> attribute of {{Instance}} returns **this**.\[[Exports]].
+</div>
+
+<div algorithm>
+    The <dfn method for="Instance">namespaceInstance(|moduleNamespace|)</dfn> method, when invoked, performs the following steps:
+    1. Assert: |namespace| is a [=Module Namespace exotic object=].
+    1. If |namespace|.\[[Module]] is not a [=WebAssembly Module Record=], [=throw=] a {{TypeError}} exception.
+    1. Let |module| be |namespace|.\[[Module]].
+    1. Return |module|.\[[Instance]].
 </div>
 
 <h3 id="memories">Memories</h3>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -320,7 +320,7 @@ namespace WebAssembly {
     Promise&lt;Instance> instantiate(
         Module moduleObject, optional object importObject);
 
-    Instance moduleInstance(ModuleNamespace namespace);
+    Instance namespaceInstance(ModuleNamespace namespace);
 };
 </pre>
 
@@ -538,7 +538,7 @@ The verification of WebAssembly type requirements is deferred to the
 </div>
 
 <div algorithm>
-  The <dfn method for="WebAssembly">moduleInstance(|namespace|)</dfn> method, when invoked, performs the following steps:
+  The <dfn method for="WebAssembly">namespaceInstance(|namespace|)</dfn> method, when invoked, performs the following steps:
     1. If |namespace| is not a [=is a Module Namespace exotic object=], [=throw=] a {{TypeError}} exception.
     1. If |namespace|.\[[Module]] is not a [=WebAssembly Module Record=], [=throw=] a {{TypeError}} exception.
     1. Let |module| be |namespace|.\[[Module]].

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -80,6 +80,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: Cyclic Module Record; url: cyclic-module-record
         text: GetMethod; url: sec-getmethod
         text: ToBigInt64; url: #sec-tobigint64
+        text: Module Namespace exotic object; url: #sec-module-namespace-exotic-objects
     type: abstract-op
         text: CreateDataPropertyOrThrow; url: sec-createdatapropertyorthrow
         text: CreateMethodProperty; url: sec-createmethodproperty
@@ -318,6 +319,8 @@ namespace WebAssembly {
 
     Promise&lt;Instance> instantiate(
         Module moduleObject, optional object importObject);
+
+    Instance moduleInstance(ModuleNamespace namespace);
 };
 </pre>
 
@@ -532,6 +535,14 @@ The verification of WebAssembly type requirements is deferred to the
 <div algorithm>
   The <dfn method for="WebAssembly">instantiate(|moduleObject|, |importObject|)</dfn> method, when invoked, performs the following steps:
     1. [=asynchronously instantiate a WebAssembly module|Asynchronously instantiate the WebAssembly module=] |moduleObject| importing |importObject|, and return the result.
+</div>
+
+<div algorithm>
+  The <dfn method for="WebAssembly">moduleInstance(|namespace|)</dfn> method, when invoked, performs the following steps:
+    1. If |namespace| is not a [=is a Module Namespace exotic object=], [=throw=] a {{TypeError}} exception.
+    1. If |namespace|.\[[Module]] is not a [=WebAssembly Module Record=], [=throw=] a {{TypeError}} exception.
+    1. Let |module| be |namespace|.\[[Module]].
+    1. Return |module|.\[[Instance]].
 </div>
 
 Note: A follow-on streaming API is documented in the <a href="https://webassembly.github.io/spec/web-api/index.html">WebAssembly Web API</a>.


### PR DESCRIPTION
This is a PR against the PR in https://github.com/WebAssembly/esm-integration/pull/104 to address the Wasm CG feedback from @rossberg that being able to obtain global handles is still a required use case for runtime reflection on instance phase ESM Integration Wasm modules.

This is an alternative to the original suggestion in https://github.com/WebAssembly/esm-integration/pull/107, coming out of that discussion.

In this approach, we introduce a new `WebAssembly.Instance.namespaceInstance(ns) -> WebAssembly.Instance` API for obtaining the `WebAssembly.Instance` runtime instance reflection object for a WebAssembly module imported in the instance phase ESM Integration (`import * as ns from './mod.wasm'`).

This is useful because where #104 would directly provide global values in Wasm exports, the `Instance` object would provide more features such as having global runtime type introspection per https://github.com/WebAssembly/js-types/blob/main/proposals/js-types/Overview.md, and possibly other features in future.

This is something like what was previously discussed as the `instance` phase import form in the import phase discussions, providing instance reflection APIs. So doesn't seem like a major departure from existing semantics. This wouldn't be supporting or advocating a new instance phase, but could also align with it if runtime instance controller reflections for JS became useful in future.