### PR TITLE
fix: namespaceInstance ModuleNamespace IDL refactoring

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -321,7 +321,7 @@ namespace WebAssembly {
     Promise&lt;Instance> instantiate(
         Module moduleObject, optional object importObject);
 
-    Instance namespaceInstance(ModuleNamespace moduleNamespace);
+    Instance namespaceInstance(object moduleNamespace);
 };
 </pre>
 
@@ -543,7 +543,7 @@ Note: A follow-on streaming API is documented in the <a href="https://webassembl
 
 <div algorithm>
     The <dfn method for="WebAssembly">namespaceInstance(|namespace|)</dfn> method, when invoked, performs the following steps:
-    1. Assert: |namespace| is a [=Module Namespace exotic object=].
+    1. If |namespace| is not a [=Module Namespace exotic object=] with a \[[Module]] internal slot, [=throw=] a {{TypeError}} exception.
     1. If |namespace|.\[[Module]] is not a [=WebAssembly Module Record=], [=throw=] a {{TypeError}} exception.
     1. Let |module| be |namespace|.\[[Module]].
     1. Return |module|.\[[Instance]].


### PR DESCRIPTION
This simplifies the definition of `WebAssembly.namespaceInstance` to instead not depend on JS `ModuleNamespace` being defined in WebIDL per https://github.com/whatwg/webidl/pull/1483.

Rather if this lands at a future date, then we could refactor to use that approach.