### PR TITLE
test: WPT source phase identity test and fixup header comment

### DIFF
--- a/test/js-api/esm-integration/mutable-global-sharing.tentative.any.js
+++ b/test/js-api/esm-integration/mutable-global-sharing.tentative.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,jsshell,shadowrealm
+
 promise_test(async () => {
   const exporterModule = await import("./resources/mutable-global-export.wasm");
   const reexporterModule = await import(

--- a/test/js-api/esm-integration/resources/source-phase-identity.js
+++ b/test/js-api/esm-integration/resources/source-phase-identity.js
@@ -1,0 +1,6 @@
+import * as mod1 from './exports.wasm';
+import * as mod2 from './exports.wasm';
+import source mod3 from './exports.wasm';
+import source mod4 from './exports.wasm';
+
+export { mod1, mod2, mod3, mod4 }

--- a/test/js-api/esm-integration/source-phase.tentative.any.js
+++ b/test/js-api/esm-integration/source-phase.tentative.any.js
@@ -40,3 +40,10 @@ promise_test(async () => {
   instance.exports.logExec();
   assert_true(logged, "WebAssembly instance should execute imported function");
 }, "Source phase imports");
+
+promise_test(async () => {
+  const { mod1, mod2, mod3, mod4 } = await import('./resources/source-phase-identity.js');
+
+  assert_equals(mod1, mod2);
+  assert_equals(mod3, mod4);
+}, "Source phase identities");


### PR DESCRIPTION
Adds an additional test for source phase identity and also fixes up the header comment in one of the tests.