### PR TITLE
String builtins merge, passing builtinSetNames and stringConstant

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -2310,8 +2310,9 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
 1. [=Compile a WebAssembly module|Compile the WebAssembly module=] |stableBytes| and store the result as |module|.
 1. If |module| is [=error=], throw a {{CompileError}} exception.
-1. Note: When integrating with the JS String Builtins proposal, |builtinSetNames| should be passed in the following step as « "js-string" » and |importedStringModule| as null.
-1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |module| be the result.
+1. Let |builtinSetNames| be « "js-string" ».
+1. Let |importedStringModule| be "wasm-js:strings".
+1. [=Construct a WebAssembly module object=] from |module|, |bytes|, |builtinSetNames| and |importedStringModule|, and let |module| be the result.
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, |name|, |type|) in [=module_imports=](|module|.\[[Module]]),
     1. If |moduleName| starts with the prefix "wasm-js:",
@@ -2409,7 +2410,6 @@ WebAssembly Module Records have the following methods:
 1. Let |module| be |record|.\[[ModuleSource]].\[[Module]].
 1. Let |imports| be « ».
 1. [=list/iterate|For each=] (|importedModuleName|, |name|, |importtype|) in [=module_imports=](|module|),
-    1. Note: The following step only applies when integrating with the JS String Builtins proposal.
     1. If [=Find a builtin=] with (|importedModuleName|, |name|) and builtins |module|.\[[BuiltinSets]] is not null, then [=iteration/continue=].
     1. Let |importedModule| be [$GetImportedModule$](|record|, |importedModuleName|).
     1. Let |resolution| be |importedModule|.ResolveExport(|name|).

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -2311,7 +2311,7 @@ To <dfn export>parse a WebAssembly module</dfn> given a <a>byte sequence</a> |by
 1. [=Compile a WebAssembly module|Compile the WebAssembly module=] |stableBytes| and store the result as |module|.
 1. If |module| is [=error=], throw a {{CompileError}} exception.
 1. Let |builtinSetNames| be « "js-string" ».
-1. Let |importedStringModule| be "wasm-js:strings".
+1. Let |importedStringModule| be "wasm:js/string-constants".
 1. [=Construct a WebAssembly module object=] from |module|, |bytes|, |builtinSetNames| and |importedStringModule|, and let |module| be the result.
 1. Let |requestedModules| be a set.
 1. For each (|moduleName|, |name|, |type|) in [=module_imports=](|module|.\[[Module]]),


### PR DESCRIPTION
With the spec now merged to the latest, we can explicitly integrate with the JS String Builtins proposal, passing the `builtinSetNames` and `stringConstant` parameters to module construction.

This explicitly now passes `« "js-string" »` for the builtinset.

For the string constant, we had a bikeshed discussion in https://github.com/WebAssembly/esm-integration/issues/118, which led to the conclusion of `wasm:js/string-constants`, which is specified here as well.

// cc @eqrion 